### PR TITLE
Fix sf_service_config so that it generates mockable code

### DIFF
--- a/inc/sf_c_util/sf_service_config.h
+++ b/inc/sf_c_util/sf_service_config.h
@@ -69,7 +69,7 @@ typedef THANDLE(RC_STRING) thandle_rc_string;
     /*Codes_SRS_SF_SERVICE_CONFIG_42_002: [ DECLARE_SF_SERVICE_CONFIG shall generate a mockable create function SF_SERVICE_CONFIG_CREATE(name) which takes an IFabricCodePackageActivationContext* and produces the THANDLE. ]*/ \
     MOCKABLE_FUNCTION(, THANDLE(SF_SERVICE_CONFIG(name)), SF_SERVICE_CONFIG_CREATE(name), IFabricCodePackageActivationContext*, activation_context); \
     /*Codes_SRS_SF_SERVICE_CONFIG_42_003: [ DECLARE_SF_SERVICE_CONFIG shall generate mockable getter functions SF_SERVICE_CONFIG_GETTER(name, param) for each of the configurations provided. ]*/ \
-    SF_SERVICE_CONFIG_EXPANDED_MU_FOR_EACH_2_KEEP_1(DECLARE_SF_SERVICE_CONFIG_GETTER, name, SF_SERVICE_CONFIG_EXPAND_PARAMS(__VA_ARGS__))
+    SF_SERVICE_CONFIG_EXPANDED_MU_FOR_EACH_2_KEEP_2(DECLARE_SF_SERVICE_CONFIG_GETTER, name, dummy, SF_SERVICE_CONFIG_EXPAND_PARAMS(__VA_ARGS__))
 
 
 // Define configuration (for .c file)
@@ -124,7 +124,10 @@ typedef THANDLE(RC_STRING) thandle_rc_string;
 
 // Helpers for Declare
 
-#define DECLARE_SF_SERVICE_CONFIG_GETTER(name, type, param) \
+// NOTE that we have a dummy variable here so we can use MU_FOR_EACH_2_KEEP_2 instead of MU_FOR_EACH_2_KEEP_1.
+// The reason is that MOCKABLE_FUNCTION uses MU_FOR_EACH_2_KEEP_1, and we cannot nest the same macro name
+
+#define DECLARE_SF_SERVICE_CONFIG_GETTER(name, dummy, type, param) \
     MOCKABLE_FUNCTION(, SF_SERVICE_CONFIG_RETURN_TYPE(type), SF_SERVICE_CONFIG_GETTER(name, param), THANDLE(SF_SERVICE_CONFIG(name)), handle);
 
 // Helpers for Define

--- a/tests/sf_service_config_ut/sf_service_config_ut_helpers.h
+++ b/tests/sf_service_config_ut/sf_service_config_ut_helpers.h
@@ -147,6 +147,7 @@
         (void)activation_context; \
         (void)config_package_name; \
         (void)section_name; \
+        (void)value; /*maybe not set, e.g. if there are no configs of this type */ \
         if (parameter_name == NULL || parameter_name[0] == L'\0') \
         { \
             result = MU_FAILURE; \


### PR DESCRIPTION
The existing code would not compile because it generated nested `MU_FOR_EACH_2_KEEP_1` macros when the mocks were generated. This work-around uses `MU_FOR_EACH_2_KEEP_2` instead and adds a test that mocking works.