### PR TITLE
Split DECLARE_SF_SERVICE_CONFIG into DECLARE_SF_SERVICE_CONFIG_HANDLE and DECLARE_SF_SERVICE_CONFIG_GETTERS

### DIFF
--- a/devdoc/sf_service_config_requirements.md
+++ b/devdoc/sf_service_config_requirements.md
@@ -85,6 +85,12 @@ SF Config XML
 #define SF_SERVICE_CONFIG_CREATE(name) MU_C2(name, _configuration_create)
 #define SF_SERVICE_CONFIG_GETTER(name, param) MU_C3(name, _configuration_get_, param)
 
+#define DECLARE_SF_SERVICE_CONFIG_HANDLE(name, ...) \
+    //...
+
+#define DECLARE_SF_SERVICE_CONFIG_GETTERS(name, ...) \
+    //...
+
 #define DECLARE_SF_SERVICE_CONFIG(name, ...) \
     //...
 
@@ -95,20 +101,38 @@ SF Config XML
 ### DECLARE_SF_SERVICE_CONFIG
 
 ```c
-#define DECLARE_SF_SERVICE_CONFIG(name, ...)
+#define DECLARE_SF_SERVICE_CONFIG_HANDLE(name, ...)
 ```
 
-Creates all declarations for the configuration type `SF_SERVICE_CONFIG(name)`. This includes the mockable create, which produces a `THANDLE`, and all of the mockable getters for the parameters specified.
+Creates all declarations for the configuration type `SF_SERVICE_CONFIG(name)`. This includes the `THANDLE` type and a mockable create, which produces a `THANDLE`, and all of the mockable getters for the parameters specified.
+
+**SRS_SF_SERVICE_CONFIG_42_001: [** `DECLARE_SF_SERVICE_CONFIG_HANDLE` shall generate a `THANDLE` declaration of type `SF_SERVICE_CONFIG(name)`. **]**
+
+### DECLARE_SF_SERVICE_CONFIG_GETTERS
+
+```c
+#define DECLARE_SF_SERVICE_CONFIG_GETTERS(name, ...)
+```
+
+Creates all declarations for the configuration type `SF_SERVICE_CONFIG(name)` mockable getters for the parameters specified.
 
 Each parameter must be in the form `CONFIG_REQUIRED(type, config_name)` or `CONFIG_OPTIONAL(type, config_name)`, for configurations that are required or optional, respectively. Required configs must be found in the SF configuration or the configuration create will fail, optional configs may be absent and a default (e.g. empty string) will be used.
 
 Each of these parameters with name `config_name` must also have a corresponding `SF_SERVICE_CONFIG_PARAMETER_NAME_config_name` defined with a wide string for the name of the config value as specified in the SF XML.
 
-**SRS_SF_SERVICE_CONFIG_42_001: [** `DECLARE_SF_SERVICE_CONFIG` shall generate a `THANDLE` declaration of type `SF_SERVICE_CONFIG(name)`. **]**
+**SRS_SF_SERVICE_CONFIG_42_002: [** `DECLARE_SF_SERVICE_CONFIG_GETTERS` shall generate a mockable create function `SF_SERVICE_CONFIG_CREATE(name)` which takes an `IFabricCodePackageActivationContext*` and produces the `THANDLE`. **]**
 
-**SRS_SF_SERVICE_CONFIG_42_002: [** `DECLARE_SF_SERVICE_CONFIG` shall generate a mockable create function `SF_SERVICE_CONFIG_CREATE(name)` which takes an `IFabricCodePackageActivationContext*` and produces the `THANDLE`. **]**
+**SRS_SF_SERVICE_CONFIG_42_003: [** `DECLARE_SF_SERVICE_CONFIG_GETTERS` shall generate mockable getter functions `SF_SERVICE_CONFIG_GETTER(name, param)` for each of the configurations provided. **]**
 
-**SRS_SF_SERVICE_CONFIG_42_003: [** `DECLARE_SF_SERVICE_CONFIG` shall generate mockable getter functions `SF_SERVICE_CONFIG_GETTER(name, param)` for each of the configurations provided. **]**
+### DECLARE_SF_SERVICE_CONFIG
+
+```c
+#define DECLARE_SF_SERVICE_CONFIG(name, ...)
+```
+
+Creates all declarations for the configuration type `SF_SERVICE_CONFIG(name)`. This includes the mockable create, which produces a `THANDLE`, and all of the mockable getters for the parameters specified.
+
+`DECLARE_SF_SERVICE_CONFIG` is a convenience macro that expans to `DECLARE_SF_SERVICE_CONFIG_HANDLE` and `DECLARE_SF_SERVICE_CONFIG_GETTERS`.
 
 ### DEFINE_SF_SERVICE_CONFIG
 

--- a/inc/sf_c_util/sf_service_config.h
+++ b/inc/sf_c_util/sf_service_config.h
@@ -60,17 +60,23 @@ typedef THANDLE(RC_STRING) thandle_rc_string;
 
 #define SF_SERVICE_CONFIG_PARAMETER_NAME(name) MU_C2(SF_SERVICE_CONFIG_PARAMETER_NAME_, name)
 
+#define DECLARE_SF_SERVICE_CONFIG_HANDLE(name, ...) \
+    /*Codes_SRS_SF_SERVICE_CONFIG_42_001: [ DECLARE_SF_SERVICE_CONFIG_HANDLE shall generate a THANDLE declaration of type SF_SERVICE_CONFIG(name). ]*/ \
+    typedef struct MU_C2(name, _CONFIGURATION_TAG) SF_SERVICE_CONFIG(name); \
+    THANDLE_TYPE_DECLARE(SF_SERVICE_CONFIG(name)); \
+    /*Codes_SRS_SF_SERVICE_CONFIG_42_002: [ DECLARE_SF_SERVICE_CONFIG_GETTERS shall generate a mockable create function SF_SERVICE_CONFIG_CREATE(name) which takes an IFabricCodePackageActivationContext* and produces the THANDLE. ]*/ \
+    MOCKABLE_FUNCTION(, THANDLE(SF_SERVICE_CONFIG(name)), SF_SERVICE_CONFIG_CREATE(name), IFabricCodePackageActivationContext*, activation_context); \
+    /*Codes_SRS_SF_SERVICE_CONFIG_42_003: [ DECLARE_SF_SERVICE_CONFIG_GETTERS shall generate mockable getter functions SF_SERVICE_CONFIG_GETTER(name, param) for each of the configurations provided. ]*/ \
+
+// separated macro so that it can be used directly in order to allow more options to be declared/defined
+#define DECLARE_SF_SERVICE_CONFIG_GETTERS(name, ...) \
+    SF_SERVICE_CONFIG_EXPANDED_MU_FOR_EACH_2_KEEP_2(DECLARE_SF_SERVICE_CONFIG_GETTER, name, dummy, SF_SERVICE_CONFIG_EXPAND_PARAMS(__VA_ARGS__))
+
 // Declare configuration (for header)
 
 #define DECLARE_SF_SERVICE_CONFIG(name, ...) \
-    /*Codes_SRS_SF_SERVICE_CONFIG_42_001: [ DECLARE_SF_SERVICE_CONFIG shall generate a THANDLE declaration of type SF_SERVICE_CONFIG(name). ]*/ \
-    typedef struct MU_C2(name, _CONFIGURATION_TAG) SF_SERVICE_CONFIG(name); \
-    THANDLE_TYPE_DECLARE(SF_SERVICE_CONFIG(name)); \
-    /*Codes_SRS_SF_SERVICE_CONFIG_42_002: [ DECLARE_SF_SERVICE_CONFIG shall generate a mockable create function SF_SERVICE_CONFIG_CREATE(name) which takes an IFabricCodePackageActivationContext* and produces the THANDLE. ]*/ \
-    MOCKABLE_FUNCTION(, THANDLE(SF_SERVICE_CONFIG(name)), SF_SERVICE_CONFIG_CREATE(name), IFabricCodePackageActivationContext*, activation_context); \
-    /*Codes_SRS_SF_SERVICE_CONFIG_42_003: [ DECLARE_SF_SERVICE_CONFIG shall generate mockable getter functions SF_SERVICE_CONFIG_GETTER(name, param) for each of the configurations provided. ]*/ \
-    SF_SERVICE_CONFIG_EXPANDED_MU_FOR_EACH_2_KEEP_2(DECLARE_SF_SERVICE_CONFIG_GETTER, name, dummy, SF_SERVICE_CONFIG_EXPAND_PARAMS(__VA_ARGS__))
-
+    DECLARE_SF_SERVICE_CONFIG_HANDLE(name) \
+    DECLARE_SF_SERVICE_CONFIG_GETTERS(name, __VA_ARGS__)
 
 // Define configuration (for .c file)
 

--- a/tests/sf_service_config_ut/sf_service_config_ut.c
+++ b/tests/sf_service_config_ut/sf_service_config_ut.c
@@ -207,7 +207,7 @@ TEST_FUNCTION(SF_SERVICE_CONFIG_GETTER_is_mockable)
     ASSERT_ARE_EQUAL(uint64_t, 42, result);
 }
 
-/*Tests_SRS_SF_SERVICE_CONFIG_42_001: [ DECLARE_SF_SERVICE_CONFIG shall generate a THANDLE declaration of type SF_SERVICE_CONFIG(name). ]*/
+/*Tests_SRS_SF_SERVICE_CONFIG_42_001: [ DECLARE_SF_SERVICE_CONFIG_HANDLE shall generate a THANDLE declaration of type SF_SERVICE_CONFIG(name). ]*/
 static THANDLE(my_config_CONFIGURATION) my_config_CONFIGURATION_has_THANDLE = NULL;
 
 // Tested implicitly in the cases below
@@ -256,7 +256,7 @@ TEST_FUNCTION(SF_SERVICE_CONFIG_CREATE_with_NULL_activation_context_fails)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-/*Tests_SRS_SF_SERVICE_CONFIG_42_002: [ DECLARE_SF_SERVICE_CONFIG shall generate a mockable create function SF_SERVICE_CONFIG_CREATE(name) which takes an IFabricCodePackageActivationContext* and produces the THANDLE. ]*/
+/*Tests_SRS_SF_SERVICE_CONFIG_42_002: [ DECLARE_SF_SERVICE_CONFIG_GETTERS shall generate a mockable create function SF_SERVICE_CONFIG_CREATE(name) which takes an IFabricCodePackageActivationContext* and produces the THANDLE. ]*/
 /*Tests_SRS_SF_SERVICE_CONFIG_42_010: [ SF_SERVICE_CONFIG_CREATE(name) shall allocate the THANDLE(SF_SERVICE_CONFIG(name)) with MU_C2A(SF_SERVICE_CONFIG(name), _dispose) as the dispose function. ]*/
 /*Tests_SRS_SF_SERVICE_CONFIG_42_011: [ SF_SERVICE_CONFIG_CREATE(name) shall call AddRef and store the activation_context. ]*/
 /*Tests_SRS_SF_SERVICE_CONFIG_42_012: [ SF_SERVICE_CONFIG_CREATE(name) shall store the sf_config_name and sf_parameters_section_name. ]*/
@@ -696,7 +696,7 @@ TEST_FUNCTION(SF_SERVICE_CONFIG_GETTER_for_thandle_rc_string_with_NULL_handle_re
     THANDLE_ASSIGN(SF_SERVICE_CONFIG(my_config))(&config, NULL);
 }
 
-/*Tests_SRS_SF_SERVICE_CONFIG_42_003: [ DECLARE_SF_SERVICE_CONFIG shall generate mockable getter functions SF_SERVICE_CONFIG_GETTER(name, param) for each of the configurations provided. ]*/
+/*Tests_SRS_SF_SERVICE_CONFIG_42_003: [ DECLARE_SF_SERVICE_CONFIG_GETTERS shall generate mockable getter functions SF_SERVICE_CONFIG_GETTER(name, param) for each of the configurations provided. ]*/
 /*Tests_SRS_SF_SERVICE_CONFIG_42_050: [ SF_SERVICE_CONFIG_GETTER(name, field_name) shall return the configuration value for field_name. ]*/
 TEST_FUNCTION(SF_SERVICE_CONFIG_GETTER_for_bool_with_true_value_returns_true)
 {


### PR DESCRIPTION
Split DECLARE_SF_SERVICE_CONFIG into DECLARE_SF_SERVICE_CONFIG_HANDLE and DECLARE_SF_SERVICE_CONFIG_GETTERS so that we can use more options in the config