### PR TITLE
Handle FABRIC_E_TIMEOUT as a transient error code

### DIFF
--- a/sfwrapper/devdoc/h_fabric_macro_generator_requirements.md
+++ b/sfwrapper/devdoc/h_fabric_macro_generator_requirements.md
@@ -197,7 +197,7 @@ The macro `H_FABRIC_DEFINE_API_WITH_RESULTS` adds the optional parameter `perman
 
 **SRS_H_FABRIC_MACRO_GENERATOR_02_010: [** If the call succeeds then `H_FABRIC_API(IFABRIC_METHOD_NAME)` shall succeed and return. **]**
 
-**SRS_H_FABRIC_MACRO_GENERATOR_02_011: [** If the result is `FABRIC_E_OBJECT_CLOSED`, `FABRIC_E_GATEWAY_NOT_REACHABLE` or `E_ABORT` then `H_FABRIC_API(IFABRIC_METHOD_NAME)` shall create a new instance of `IFABRIC_INTERFACE_NAME`. **]**
+**SRS_H_FABRIC_MACRO_GENERATOR_02_011: [** If the result is `FABRIC_E_OBJECT_CLOSED`, `FABRIC_E_GATEWAY_NOT_REACHABLE`, `FABRIC_E_TIMEOUT` or `E_ABORT` then `H_FABRIC_API(IFABRIC_METHOD_NAME)` shall create a new instance of `IFABRIC_INTERFACE_NAME`. **]**
 
 **SRS_H_FABRIC_MACRO_GENERATOR_02_012: [** If creating the new instance of `IFABRIC_INTERFACE_NAME` fails then `H_FABRIC_API(IFABRIC_METHOD_NAME)` shall retry using the existing `IFABRIC_INTERFACE_NAME`. **]**
 

--- a/sfwrapper/inc/h_fabric_macro_generator.h
+++ b/sfwrapper/inc/h_fabric_macro_generator.h
@@ -238,8 +238,10 @@ HRESULT H_FABRIC_API(IFABRIC_METHOD_NAME)(H_FABRIC_HANDLE(IFABRIC_INTERFACE_NAME
                 LogHRESULTError(hr, "failure in " MU_TOSTRING(IFABRIC_METHOD_NAME) "(handle->This=%p, ...)",                                                                                \
                     handle->This);                                                                                                                                                          \
                                                                                                                                                                                             \
-                /*Codes_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/ \
-                if ((hr == E_ABORT) || (hr == FABRIC_E_OBJECT_CLOSED) || (hr == FABRIC_E_GATEWAY_NOT_REACHABLE))                                                                            \
+                /*Codes_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE, FABRIC_E_TIMEOUT or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/ \
+                /* FABRIC_E_TIMEOUT was observed in certain cases, such as RestartPartition. We should retry by creating a new client and trying the call again, */                         \
+                /* up to the timeout specified in the H_FABRIC_HANDLE. */                                                                                                                   \
+                if ((hr == E_ABORT) || (hr == FABRIC_E_OBJECT_CLOSED) || (hr == FABRIC_E_GATEWAY_NOT_REACHABLE) || (hr == FABRIC_E_TIMEOUT))                                                \
                 {                                                                                                                                                                           \
                     IFABRIC_INTERFACE_NAME* newInstance = NULL;                                                                                                                             \
                                                                                                                                                                                             \

--- a/sfwrapper/tests/h_fabric_macro_generator_ut/h_fabric_macro_generator_ut.c
+++ b/sfwrapper/tests/h_fabric_macro_generator_ut/h_fabric_macro_generator_ut.c
@@ -241,7 +241,7 @@ TEST_FUNCTION(H_FABRIC_API_IFABRIC_METHOD_NAME_succeeds)
     H_FABRIC_HANDLE_DESTROY(IFabricZZZZ)(result);
 }
 
-/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE, FABRIC_E_TIMEOUT or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_013: [ Otherwise H_FABRIC_API(IFABRIC_METHOD_NAME) shall release the existing instance and shall retry using new newly created IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_015: [ H_FABRIC_API(IFABRIC_METHOD_NAME) shall sleep msBetweenRetries. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_010: [ If the call succeeds then H_FABRIC_API(IFABRIC_METHOD_NAME) shall succeed and return. ]*/
@@ -276,7 +276,7 @@ TEST_FUNCTION(H_FABRIC_API_IFABRIC_METHOD_NAME_succeeds_after_1_retry_with_E_ABO
     H_FABRIC_HANDLE_DESTROY(IFabricZZZZ)(result);
 }
 
-/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE, FABRIC_E_TIMEOUT or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_013: [ Otherwise H_FABRIC_API(IFABRIC_METHOD_NAME) shall release the existing instance and shall retry using new newly created IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_015: [ H_FABRIC_API(IFABRIC_METHOD_NAME) shall sleep msBetweenRetries. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_010: [ If the call succeeds then H_FABRIC_API(IFABRIC_METHOD_NAME) shall succeed and return. ]*/
@@ -311,7 +311,42 @@ TEST_FUNCTION(H_FABRIC_API_IFABRIC_METHOD_NAME_succeeds_after_1_retry_with_FABRI
     H_FABRIC_HANDLE_DESTROY(IFabricZZZZ)(result);
 }
 
-/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE, FABRIC_E_TIMEOUT or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_013: [ Otherwise H_FABRIC_API(IFABRIC_METHOD_NAME) shall release the existing instance and shall retry using new newly created IFABRIC_INTERFACE_NAME. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_015: [ H_FABRIC_API(IFABRIC_METHOD_NAME) shall sleep msBetweenRetries. ]*/
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_010: [ If the call succeeds then H_FABRIC_API(IFABRIC_METHOD_NAME) shall succeed and return. ]*/
+TEST_FUNCTION(H_FABRIC_API_IFABRIC_METHOD_NAME_succeeds_after_1_retry_with_FABRIC_E_TIMEOUT)
+{
+    ///arrange
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(CREATE_IFABRICINSTANCE_NAME(IFabricZZZZ)(IGNORED_ARG));
+    H_FABRIC_HANDLE(IFabricZZZZ) result = H_FABRIC_HANDLE_CREATE(IFabricZZZZ)(3, TIME_MS_BETWEEN_RETRIES); /*3 retries, 0.1 s between retries*/
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    STRICT_EXPECTED_CALL(timer_global_get_elapsed_ms())
+        .SetReturn(TIME_START_OF_TIME);
+    STRICT_EXPECTED_CALL(DoSomethingAwesome(IGNORED_ARG, "a", TIME_TIMEOUT))
+        .SetReturn(FABRIC_E_TIMEOUT);
+    /*because of E_ABORT the object is recreated*/
+    STRICT_EXPECTED_CALL(CREATE_IFABRICINSTANCE_NAME(IFabricZZZZ)(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(DoNothingRelease(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(ThreadAPI_Sleep(TIME_MS_BETWEEN_RETRIES));
+    STRICT_EXPECTED_CALL(timer_global_get_elapsed_ms())
+        .SetReturn(TIME_START_OF_TIME + 100);
+    STRICT_EXPECTED_CALL(DoSomethingAwesome(IGNORED_ARG, "a", TIME_TIMEOUT));
+
+    ///act
+    HRESULT hr = H_FABRIC_API(DoSomethingAwesome)(result, "a", TIME_TIMEOUT);
+
+    ///assert
+    ASSERT_IS_TRUE(SUCCEEDED(hr));
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///clean
+    H_FABRIC_HANDLE_DESTROY(IFabricZZZZ)(result);
+}
+
+/*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_011: [ If the result is FABRIC_E_OBJECT_CLOSED, FABRIC_E_GATEWAY_NOT_REACHABLE, FABRIC_E_TIMEOUT or E_ABORT then H_FABRIC_API(IFABRIC_METHOD_NAME) shall create a new instance of IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_013: [ Otherwise H_FABRIC_API(IFABRIC_METHOD_NAME) shall release the existing instance and shall retry using new newly created IFABRIC_INTERFACE_NAME. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_015: [ H_FABRIC_API(IFABRIC_METHOD_NAME) shall sleep msBetweenRetries. ]*/
 /*Tests_SRS_H_FABRIC_MACRO_GENERATOR_02_010: [ If the call succeeds then H_FABRIC_API(IFABRIC_METHOD_NAME) shall succeed and return. ]*/


### PR DESCRIPTION
Handle FABRIC_E_TIMEOUT as a transient error code.
This was observed in certain cases, such as RestartPartition where the sf_test_helper issued a RestartPartition, but a FABRIC_E_TIMEOUT was returned by the fabric API call, even though the timeout for the H_FABRIC_HANDLE did not elapse yet.