### PR TITLE
[MrBot] Add build_reals option to gate reals libraries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,9 @@
 #Copyright (C) Microsoft Corporation. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-add_subdirectory(reals)
+if(${build_reals})
+    add_subdirectory(reals)
+endif()
 
 # unit tests
 if(${run_unittests})


### PR DESCRIPTION
## Summary
Add `build_reals` CMake option to gate reals libraries behind a flag.

## Motivation
The `build_reals` option (default ON) allows disabling the building of reals libraries when they are not needed — such as in official builds, integration test builds, and performance test builds. Reals are only consumed by unit tests, so excluding them from non-unit-test configurations reduces build times.

This is part of a broader effort to reduce the Azure-MessagingStore official simulation build time (currently ~86 min).

## Changes
- Gate `add_subdirectory(reals)` in `tests/CMakeLists.txt` behind `if(\${build_reals})`