### PR TITLE
Enable arm64_max_stage ALL for ARM64 CI leg in devops_gated.yml

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -30,6 +30,7 @@ jobs:
     GBALLOC_LL_TYPE_VALUES: ["PASSTHROUGH", "JEMALLOC"]
     pool_name_x64: ${{ parameters.pool_name_windows_x64 }}
     pool_name_arm64: ${{ parameters.pool_name_windows_arm64 }}
+    arm64_max_stage: ALL
     # Run NuGetAuthenticate + NuGetToolInstaller before cmake so the
     # SF NuGet restore in deps/servicefabric/CMakeLists.txt can reach
     # the auth-protected Azure-MessagingStore-Feed (which has the SF


### PR DESCRIPTION
Opt the sf-c-util ARM64 test leg into running every registered test category (unit, int, perf, e2e) by passing arm64_max_stage: ALL to build_all_flavors.yml, matching c-util and ctest. The pinned c_build_tools ref already exposes this parameter.